### PR TITLE
fix ROS<>LCM message converter for Unitree SDK v3.5.0

### DIFF
--- a/unitree_legged_real/include/convert.h
+++ b/unitree_legged_real/include/convert.h
@@ -105,9 +105,9 @@ unitree_legged_msgs::LowState ToRos(UNITREE_LEGGED_SDK::LowState& lcm)
 {
     unitree_legged_msgs::LowState ros;
     ros.levelFlag = lcm.levelFlag;
-    ros.commVersion = lcm.commVersion;
-    ros.robotID = lcm.robotID;
-    ros.SN = lcm.SN;
+    ros.commVersion = lcm.version[0];
+    ros.robotID = lcm.version[1];
+    ros.SN = lcm.SN[0];
     ros.bandWidth = lcm.bandWidth;
     ros.imu = ToRos(lcm.imu);
     for(int i = 0; i<20; i++){
@@ -131,9 +131,9 @@ UNITREE_LEGGED_SDK::LowCmd ToLcm(unitree_legged_msgs::LowCmd& ros, UNITREE_LEGGE
 {
     UNITREE_LEGGED_SDK::LowCmd lcm;
     lcm.levelFlag = ros.levelFlag;
-    lcm.commVersion = ros.commVersion;
-    lcm.robotID = ros.robotID;
-    lcm.SN = ros.SN;
+    lcm.version[0] = ros.commVersion;
+    lcm.version[1] = ros.robotID;
+    lcm.SN[0] = ros.SN;
     lcm.bandWidth = ros.bandWidth;
     for(int i = 0; i<20; i++){
         lcm.motorCmd[i] = ToLcm(ros.motorCmd[i], lcm.motorCmd[i]);
@@ -151,9 +151,9 @@ unitree_legged_msgs::HighState ToRos(UNITREE_LEGGED_SDK::HighState& lcm)
 {
     unitree_legged_msgs::HighState ros;
     ros.levelFlag = lcm.levelFlag;
-    ros.commVersion = lcm.commVersion;
-    ros.robotID = lcm.robotID;
-    ros.SN = lcm.SN;
+    ros.commVersion = lcm.version[0];
+    ros.robotID = lcm.version[1];
+    ros.SN = lcm.SN[0];
     ros.bandWidth = lcm.bandWidth;
     ros.mode = lcm.mode;
     ros.progress = lcm.progress;
@@ -193,9 +193,9 @@ UNITREE_LEGGED_SDK::HighCmd ToLcm(unitree_legged_msgs::HighCmd& ros, UNITREE_LEG
 {
     UNITREE_LEGGED_SDK::HighCmd lcm;
     lcm.levelFlag = ros.levelFlag;
-    lcm.commVersion = ros.commVersion;
-    lcm.robotID = ros.robotID;
-    lcm.SN = ros.SN;
+    lcm.version[0] = ros.commVersion;
+    lcm.version[1] = ros.robotID;
+    lcm.SN[0] = ros.SN;
     lcm.bandWidth = ros.bandWidth;
     lcm.mode = ros.mode;
     lcm.gaitType = ros.gaitType;


### PR DESCRIPTION
To compile `unitree_ros_to_real` aginast `unitree_legged_sdk v3.5.0 and above, https://github.com/unitreerobotics/unitree_legged_sdk/commit/1cca3a3a223498daad2bcddd6d3759ee46b7cc30 breaks `ToRos` `ToLcm` functions.
This change fixes compile following compile error
```
boost_chrono -lboost_date_time -lboost_atomic -lpthread /usr/lib/x86_64-linux-gnu/libconsole_bridge.so.0.4 
[unitree_legged_real:make] make[2]: Leaving directory '/home/k-okada/catkin_ws/ws_unitree/build/unitree_legged_real'
[unitree_legged_real:make] [ 60%] Built target lcm_server                                                    
[unitree_legged_real:make] In file included from /home/k-okada/catkin_ws/ws_unitree/src/unitree_ros_to_real/unitree_legged_real/src/exe/velocity_mode.cpp:13:0:
[unitree_legged_real:make] /home/k-okada/catkin_ws/ws_unitree/src/unitree_ros_to_real/unitree_legged_real/include/convert.h: In function ‘unitree_legged_msgs::LowState ToRos(UNITREE_LEGGED_SDK::LowState&)’:
[unitree_legged_real:make] /home/k-okada/catkin_ws/ws_unitree/src/unitree_ros_to_real/unitree_legged_real/include/convert.h:108:27: error: ‘struct UNITREE_LEGGED_SDK::LowState’ has no member named ‘commVersion’; did you mean ‘version’?
[unitree_legged_real:make]      ros.commVersion = lcm.commVersion;
[unitree_legged_real:make]                            ^~~~~~~~~~~
[unitree_legged_real:make]                            version
[unitree_legged_real:make] /home/k-okada/catkin_ws/ws_unitree/src/unitree_ros_to_real/unitree_legged_real/include/convert.h:109:23: error: ‘struct UNITREE_LEGGED_SDK::LowState’ has no member named ‘robotID’
[unitree_legged_real:make]      ros.robotID = lcm.robotID;
[unitree_legged_real:make]                        ^~~~~~~
[unitree_legged_real:make] /home/k-okada/catkin_ws/ws_unitree/src/unitree_ros_to_real/unitree_legged_real/include/convert.h:110:18: error: cannot convert ‘std::array<unsigned int, 2>’ to ‘unitree_legged_msgs::LowState_<std::allocator<void> >::_SN_type {aka unsigned int}’ in assignment
[unitree_legged_real:make]      ros.SN = lcm.SN;
[unitree_legged_real:make]                   ^~
[unitree_legged_real:make] /home/k-okada/catkin_ws/ws_unitree/src/unitree_ros_to_real/unitree_legged_real/include/convert.h: In function ‘UNITREE_LEGGED_SDK::LowCmd ToLcm(unitree_legged_msgs::LowCmd&, UNITREE_LEGGED_SDK::LowCmd)’:
[unitree_legged_real:make] /home/k-okada/catkin_ws/ws_unitree/src/unitree_ros_to_real/unitree_legged_real/include/convert.h:134:9: error: ‘struct UNITREE_LEGGED_SDK::LowCmd’ has no member named ‘commVersion’; did you mean ‘version’?
[unitree_legged_real:make]      lcm.commVersion = ros.commVersion;
[unitree_legged_real:make]          ^~~~~~~~~~~
[unitree_legged_real:make]          version
[unitree_legged_real:make] /home/k-okada/catkin_ws/ws_unitree/src/unitree_ros_to_real/unitree_legged_real/include/convert.h:135:9: error: ‘struct UNITREE_LEGGED_SDK::LowCmd’ has no member named ‘robotID’
[unitree_legged_real:make]      lcm.robotID = ros.robotID;

```