### PR TITLE
Stop clobbering CMAKE_CXX_FLAGS

### DIFF
--- a/unitree_legged_real/CMakeLists.txt
+++ b/unitree_legged_real/CMakeLists.txt
@@ -22,7 +22,7 @@ set(LEGGED_SDK_NAME -pthread libunitree_legged_sdk_${ARCH}.so lcm)
 set(EXTRA_LIBS ${LEGGED_SDK_NAME} lcm)
 
 
-set(CMAKE_CXX_FLAGS "-O3 -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fPIC")
 
 
 


### PR DESCRIPTION
Previously, this would overwrite `CMAKE_CXX_FLAGS`, causing builds to fail in cases where the flags were needed. This appends, rather than overwrites the flags.